### PR TITLE
Add support for OpenBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ regex = "0.2.1"
 shellexpand = "1.0.0"
 toml = "0.3.0"
 url = "1.4.0"
+unicode-bidi = "= 0.3.3" # for rust 1.16 compat
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2.8"

--- a/src/util.rs
+++ b/src/util.rs
@@ -119,6 +119,9 @@ pub static OS_NAME: &'static str = "linux";
 #[cfg(target_os = "freebsd")]
 pub static OS_NAME: &'static str = "freebsd";
 
+#[cfg(target_os = "openbsd")]
+pub static OS_NAME: &'static str = "openbsd";
+
 // create an instance of PathBuf from string.
 pub fn make_pathbuf(path: &str) -> PathBuf {
     let path = path.replace("/", &format!("{}", MAIN_SEPARATOR));


### PR DESCRIPTION
OpenBSD currently only has rust 1.16.0 available so getting it to build required pinning `unicode-bidi` at a slightly earlier version as they're using syntax introduced in 1.17.0 in the latest version.