### PR TITLE
Upgrade to support Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,12 @@ description = "Alternative of dotfile management frameworks"
 [dependencies]
 ansi_term = "0.9"
 clap = "2.20"
-error-chain = "0.11"
+error-chain = "0.12.1"
 regex = "0.2.1"
 shellexpand = "1"
 toml = "0.4"
 url = "1.5"
+dirs = "2.0.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "dot"
 version = "0.1.4"
 authors = ["Yusuke Sasaki <yusuke.sasaki.nuem@gmail.com>"]
 description = "Alternative of dotfile management frameworks"
+edition = "2018"
 
 [dependencies]
 ansi_term = "0.9"

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,6 +10,7 @@ use regex::Regex;
 #[cfg(windows)]
 use windows;
 
+extern crate dirs;
 
 pub struct App {
     dotfiles: Dotfiles,
@@ -106,7 +107,7 @@ pub fn check_symlink_privilege() {}
 
 fn init_envs() -> Result<String> {
     if env::var("HOME").is_err() {
-        env::set_var("HOME", env::home_dir().unwrap().to_str().unwrap());
+        env::set_var("HOME", dirs::home_dir().unwrap());
     }
 
     let dotdir = env::var("DOT_DIR")

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,11 +6,10 @@ use crate::util;
 use crate::errors::Result;
 use url::Url;
 use regex::Regex;
+use dirs;
 
 #[cfg(windows)]
 use windows;
-
-extern crate dirs;
 
 pub struct App {
     dotfiles: Dotfiles,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,9 +1,9 @@
 use std::borrow::Borrow;
 use std::env;
 use std::path::Path;
-use dotfiles::Dotfiles;
-use util;
-use errors::Result;
+use crate::dotfiles::Dotfiles;
+use crate::util;
+use crate::errors::Result;
 use url::Url;
 use regex::Regex;
 

--- a/src/dotfiles.rs
+++ b/src/dotfiles.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
-use entry::Entry;
-use util;
+use crate::entry::Entry;
+use crate::util;
 use toml;
 
 
@@ -61,7 +61,7 @@ fn read_entries_from_key(buf: &mut Vec<Entry>, entries: &toml::value::Table, roo
 mod tests {
     use super::{Dotfiles, read_entries_from_key};
     use std::path::Path;
-    use util;
+    use crate::util;
 
     #[test]
     fn smoke_test() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,6 @@ mod errors {
     }
   }
 }
-pub use errors::*;
+pub use crate::errors::*;
 
-pub use app::App;
+pub use crate::app::App;

--- a/src/util.rs
+++ b/src/util.rs
@@ -23,7 +23,7 @@ pub fn wait_exec(cmd: &str, args: &[&str], curr_dir: Option<&Path>, dry_run: boo
         command.current_dir(curr_dir);
     }
 
-    let mut child = try!(command.spawn());
+    let mut child = command.spawn()?;
     child.wait()
          .and_then(|st| st.code().ok_or(io::Error::new(io::ErrorKind::Other, "")))
 }
@@ -60,7 +60,7 @@ pub fn make_link<P, Q>(src: P, dst: Q, dry_run: bool) -> Result<(), io::Error>
                  dst.as_ref().display());
         Ok(())
     } else {
-        try!(fs::create_dir_all(dst.as_ref().parent().unwrap()));
+        fs::create_dir_all(dst.as_ref().parent().unwrap())?;
         symlink(src, dst)
     }
 }
@@ -91,10 +91,10 @@ pub fn remove_link<P: AsRef<Path>>(dst: P, dry_run: bool) -> Result<(), io::Erro
 
 
 pub fn read_toml<P: AsRef<Path>>(path: P) -> Result<toml::value::Table, io::Error> {
-    let mut file = try!(File::open(path));
+    let mut file = File::open(path)?;
 
     let mut buf = Vec::new();
-    try!(file.read_to_end(&mut buf));
+    file.read_to_end(&mut buf)?;
 
     let content = String::from_utf8_lossy(&buf[..]).into_owned();
     toml::de::from_str(&content).map_err(|_| {
@@ -129,6 +129,6 @@ pub fn make_pathbuf(path: &str) -> PathBuf {
 }
 
 pub fn is_symlink<P: AsRef<Path>>(path: P) -> Result<bool, io::Error> {
-    let meta = try!(path.as_ref().symlink_metadata());
+    let meta = path.as_ref().symlink_metadata()?;
     Ok(meta.file_type().is_symlink())
 }


### PR DESCRIPTION
This PR resolves https://github.com/ubnt-intrepid/dot/issues/18

- changes were mostly created by running `cargo fix --editon`
- use `dirs` crate to resolve a warning about using `env` to determine the home directory
- upgrade dependency error-chain due to compile errors with previous version