### PR TITLE
Support multiple symbolic links

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For more information, run `dot help`.
 ```toml
 [general]
 gitconfig   = "~/.gitconfig"
-"vim/vimrc" = "~/.vimrc"
+"vim/vimrc" = ["~/.vimrc", "~/.config/nvim/init.vim"]
 #...
 
 [windows]

--- a/tests/dotfiles/.mappings
+++ b/tests/dotfiles/.mappings
@@ -2,12 +2,12 @@
 
 [general]
 "tmux.conf"     = "~/.tmux.conf"
-gitconfig       = "~/.gitconfig"
+gitconfig       = ["~/.gitconfig", "~/.config/git/config"]
 tigrc           = "~/.tigrc"
 zsh             = "~/.config/zsh"
 "zsh/zshenv"    = "~/.zshenv"
 "zsh/zshrc"     = "~/.zshrc"
-vim             = "~/.config/vim"
+vim             = ["~/.vim", "~/.config/nvim"]
 "vim/vimrc"     = "~/.vimrc"
 "vim/gvimrc"    = "~/.gvimrc"
 


### PR DESCRIPTION
Support multiple symbolic links.

For example.

```toml
"vim/vimrc" = ["~/.vimrc", "~/.config/nvim/init.vim"]
```
